### PR TITLE
Report title will match suite title, if present

### DIFF
--- a/priv/main.eex
+++ b/priv/main.eex
@@ -2,7 +2,7 @@
   import Benchee.Formatter.Markdown.Helpers
   import Benchee.Formatter.Markdown.Templates
 %>
-# Benchmark
+# <%= suite.configuration.title || "Benchmark" %>
 
 Benchmark run from <%= DateTime.utc_now() |> DateTime.to_string() %> UTC
 

--- a/test/benchee/formatters/markdown_integration_test.exs
+++ b/test/benchee/formatters/markdown_integration_test.exs
@@ -18,6 +18,7 @@ defmodule Benchee.Formatters.MarkdownIntegrationTest do
         memory_time: 0.01,
         warmup: 0.02,
         print: [fast_warning: false],
+        title: "My Benchmark",
         formatters: [
           {Benchee.Formatters.Markdown, file: @file_path},
           Benchee.Formatters.Console


### PR DESCRIPTION
Small change that allows users to change the title of the generated report using a field already present in Benchee's configuration struct. Reports that do not use the `title` field will not be affected.