### PR TITLE
Bugfix/input formatting

### DIFF
--- a/examples/bench/basic/README.md
+++ b/examples/bench/basic/README.md
@@ -1,6 +1,6 @@
 # Benchmark Example
 
-Benchmark run from 2019-12-29 11:41:32.981035Z UTC
+Benchmark run from 2019-12-29 20:04:23.715262Z UTC
 
 ## System
 
@@ -9,22 +9,22 @@ Benchmark suite executing on the following system:
 <table style="width: 1%">
   <tr>
     <th style="width: 1%; white-space: nowrap">Operating System</th>
-    <td>macOS</td>
+    <td>Linux</td>
   </tr><tr>
     <th style="white-space: nowrap">CPU Information</th>
-    <td style="white-space: nowrap">Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz</td>
+    <td style="white-space: nowrap">Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz</td>
   </tr><tr>
     <th style="white-space: nowrap">Number of Available Cores</th>
-    <td style="white-space: nowrap">8</td>
+    <td style="white-space: nowrap">4</td>
   </tr><tr>
     <th style="white-space: nowrap">Available Memory</th>
-    <td style="white-space: nowrap">16 GB</td>
+    <td style="white-space: nowrap">7.70 GB</td>
   </tr><tr>
     <th style="white-space: nowrap">Elixir Version</th>
     <td style="white-space: nowrap">1.9.2</td>
   </tr><tr>
     <th style="white-space: nowrap">Erlang Version</th>
-    <td style="white-space: nowrap">22.0</td>
+    <td style="white-space: nowrap">22.1.8</td>
   </tr>
 </table>
 
@@ -47,6 +47,7 @@ Benchmark suite executing with the following configuration:
 
 ## Statistics
 
+
 __Input: long_list__
 
 Run Time
@@ -61,19 +62,19 @@ Run Time
   </tr>
   <tr>
     <td style="white-space: nowrap">map.flatten</td>
-    <td style="white-space: nowrap; text-align: right">867.49</td>
-    <td style="white-space: nowrap; text-align: right">1.15 ms</td>
-    <td style="white-space: nowrap; text-align: right">±25.94%</td>
-    <td style="white-space: nowrap; text-align: right">1.23 ms</td>
-    <td style="white-space: nowrap; text-align: right">1.67 ms</td>
+    <td style="white-space: nowrap; text-align: right">407.43</td>
+    <td style="white-space: nowrap; text-align: right">2.45 ms</td>
+    <td style="white-space: nowrap; text-align: right">±28.46%</td>
+    <td style="white-space: nowrap; text-align: right">2.31 ms</td>
+    <td style="white-space: nowrap; text-align: right">3.39 ms</td>
   </tr>
   <tr>
     <td style="white-space: nowrap">flat_map</td>
-    <td style="white-space: nowrap; text-align: right">444.89</td>
-    <td style="white-space: nowrap; text-align: right">2.25 ms</td>
-    <td style="white-space: nowrap; text-align: right">±37.18%</td>
-    <td style="white-space: nowrap; text-align: right">2.48 ms</td>
-    <td style="white-space: nowrap; text-align: right">2.97 ms</td>
+    <td style="white-space: nowrap; text-align: right">183.81</td>
+    <td style="white-space: nowrap; text-align: right">5.44 ms</td>
+    <td style="white-space: nowrap; text-align: right">±65.66%</td>
+    <td style="white-space: nowrap; text-align: right">5.44 ms</td>
+    <td style="white-space: nowrap; text-align: right">7.97 ms</td>
   </tr>
 </table>
 Comparison
@@ -84,13 +85,13 @@ Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">map.flatten</td>
-    <td style="white-space: nowrap;text-align: right">867.49</td>
+    <td style="white-space: nowrap;text-align: right">407.43</td>
     <td>&nbsp;</td>
   </tr>
   <tr>
     <td style="white-space: nowrap">flat_map</td>
-    <td style="white-space: nowrap; text-align: right">444.89</td>
-    <td style="white-space: nowrap; text-align: right">1.95x</td>
+    <td style="white-space: nowrap; text-align: right">183.81</td>
+    <td style="white-space: nowrap; text-align: right">2.22x</td>
   </tr>
 </table>
 Memory Usage
@@ -112,6 +113,7 @@ Memory Usage
   </tr>
 </table>
 <hr/>
+
 __Input: short_list__
 
 Run Time
@@ -126,19 +128,19 @@ Run Time
   </tr>
   <tr>
     <td style="white-space: nowrap">map.flatten</td>
-    <td style="white-space: nowrap; text-align: right">1.03 M</td>
-    <td style="white-space: nowrap; text-align: right">0.97 μs</td>
-    <td style="white-space: nowrap; text-align: right">±212.76%</td>
-    <td style="white-space: nowrap; text-align: right">0.97 μs</td>
-    <td style="white-space: nowrap; text-align: right">2.97 μs</td>
+    <td style="white-space: nowrap; text-align: right">853.74 K</td>
+    <td style="white-space: nowrap; text-align: right">1.17 μs</td>
+    <td style="white-space: nowrap; text-align: right">±282.67%</td>
+    <td style="white-space: nowrap; text-align: right">0.85 μs</td>
+    <td style="white-space: nowrap; text-align: right">5.13 μs</td>
   </tr>
   <tr>
     <td style="white-space: nowrap">flat_map</td>
-    <td style="white-space: nowrap; text-align: right">0.77 M</td>
-    <td style="white-space: nowrap; text-align: right">1.30 μs</td>
-    <td style="white-space: nowrap; text-align: right">±194.99%</td>
-    <td style="white-space: nowrap; text-align: right">0.97 μs</td>
-    <td style="white-space: nowrap; text-align: right">1.97 μs</td>
+    <td style="white-space: nowrap; text-align: right">489.63 K</td>
+    <td style="white-space: nowrap; text-align: right">2.04 μs</td>
+    <td style="white-space: nowrap; text-align: right">±91.09%</td>
+    <td style="white-space: nowrap; text-align: right">1.75 μs</td>
+    <td style="white-space: nowrap; text-align: right">10.94 μs</td>
   </tr>
 </table>
 Comparison
@@ -149,13 +151,13 @@ Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">map.flatten</td>
-    <td style="white-space: nowrap;text-align: right">1.03 M</td>
+    <td style="white-space: nowrap;text-align: right">853.74 K</td>
     <td>&nbsp;</td>
   </tr>
   <tr>
     <td style="white-space: nowrap">flat_map</td>
-    <td style="white-space: nowrap; text-align: right">0.77 M</td>
-    <td style="white-space: nowrap; text-align: right">1.34x</td>
+    <td style="white-space: nowrap; text-align: right">489.63 K</td>
+    <td style="white-space: nowrap; text-align: right">1.74x</td>
   </tr>
 </table>
 Memory Usage

--- a/priv/input.eex
+++ b/priv/input.eex
@@ -3,6 +3,7 @@
   import Benchee.Formatter.Markdown.Helpers
 %>
 <%= if is_binary(input) do %>
+
 __Input: <%= input %>__
 
 <% end %>


### PR DESCRIPTION
Markdown wasn't recognizing that inputs after the first should be in bold and was instead printing the unformatted content with underscores. The fix to this is just to add a line before each input.

I ran the example benchmark with the change as a proof of concept, but if anyone prefers the output of the previous machine, I can remove that commit from the PR.

Also, is there anything I can do to make it easier to review and integrate PRs if I find anything else? I don't want to throw unnecessary work at anyone.