### PR TITLE
Elixir 1.11: :eex should be listed in :extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule BencheeMarkdown.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :eex]
     ]
   end
 


### PR DESCRIPTION
Warning was:
```
warning: EEx.eval_file/3 defined in application :eex is used by the current application but the current application does not directly depend on :eex. To fix this, you must do one of:

  1. If :eex is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :eex is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :eex, you may optionally skip this warning by adding [xref: [exclude: EEx] to your "def project" in mix.exs

  lib/benchee/formatters/markdown/templates.ex:30: Benchee.Formatter.Markdown.Templates.render/3
```