### PR TITLE
Ensure file dir exists

### DIFF
--- a/lib/benchee/formatters/markdown.ex
+++ b/lib/benchee/formatters/markdown.ex
@@ -45,7 +45,10 @@ defmodule Benchee.Formatters.Markdown do
   to the file defined in the initial configuration.
   """
   @impl true
-  def write(data, %{file: file}), do: File.write!(file, data)
+  def write(data, %{file: file}) do
+    File.mkdir_p!(Path.dirname(file))
+    File.write!(file, data)
+  end
 
   @doc """
   Renders a given `%Benchee.Suite{}` as makrdown.


### PR DESCRIPTION
This PR fixes a bug when an inexistent directory is specified for the file:
```
** (File.Error) could not write to file "../tmp/markdown/encode.md": no such file or directory
    (elixir 1.16.0-dev) lib/file.ex:1117: File.write!/3
    (elixir 1.16.0-dev) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    (benchee 1.1.0) lib/benchee/formatter.ex:123: Benchee.Formatter.parallel_output/2
    (benchee 1.1.0) lib/benchee/formatter.ex:60: Benchee.Formatter.output/1
    (benchee 1.1.0) lib/benchee.ex:52: Benchee.run/2
    script/encode.exs:31: (file)
```

> [!IMPORTANT]
>
> No warning is displayed and no error is raised if the directory already exists.